### PR TITLE
Use Buffer constant in await read

### DIFF
--- a/examples/ok/read.php
+++ b/examples/ok/read.php
@@ -47,8 +47,8 @@ $length = 0;
 
 await(
     all(
-        read($f1, function($data) use (& $length) { $length += strlen($data); }, null, BUFFER_LENGTH),
-        read($f2, function($data) use (& $length) { $length += strlen($data); }, null, BUFFER_LENGTH)
+        read($f1, function($data) use (& $length) { $length += strlen($data); }, BUFFER_LENGTH),
+        read($f2, function($data) use (& $length) { $length += strlen($data); }, BUFFER_LENGTH)
     )
 );
 


### PR DESCRIPTION
the read method in await mode have one extra parameter, instead to be at 4th place.

And this is a big change for the fair comparison.
Instead of getting the entries file in one time, the callable will be call many times.

```
Found 6180482 characters
Time spent without await: 0.0021400451660156
Found 6180482 characters
Time spent with await: 0.035652160644531
await is 16.66 times slower
```
